### PR TITLE
XPath 2 lower-case() and upper-case() functions

### DIFF
--- a/lib/XML/XPathEngine/Function.pm
+++ b/lib/XML/XPathEngine/Function.pm
@@ -285,6 +285,21 @@ sub normalize_space {
     return XML::XPathEngine::Literal->new($str);
 }
 
+sub lower_case {
+    my $self = shift;
+    my ($node, @params) = @_;
+    die "lower-case: Wrong number of params\n" if @params > 1;
+    my $str;
+    if (@params) {
+        $str = $params[0]->string_value;
+    }
+    else {
+        $str = $node->string_value;
+    }
+    $str = lc $str;
+    return XML::XPathEngine::Literal->new($str);
+}
+
 sub translate {
     my $self = shift;
     my ($node, @params) = @_;

--- a/lib/XML/XPathEngine/Function.pm
+++ b/lib/XML/XPathEngine/Function.pm
@@ -300,6 +300,21 @@ sub lower_case {
     return XML::XPathEngine::Literal->new($str);
 }
 
+sub upper_case {
+    my $self = shift;
+    my ($node, @params) = @_;
+    die "lower-case: Wrong number of params\n" if @params > 1;
+    my $str;
+    if (@params) {
+        $str = $params[0]->string_value;
+    }
+    else {
+        $str = $node->string_value;
+    }
+    $str = uc $str;
+    return XML::XPathEngine::Literal->new($str);
+}
+
 sub translate {
     my $self = shift;
     my ($node, @params) = @_;


### PR DESCRIPTION
I have implemented two minor additions to `XML::XPathEngine::Function`: `lower-case()` and `upper-case()`.

I would like to have it so that I can use it during parsing of dates in HTML:

``` .perl
$html_meta_date_str = $tree->findvalue(
    '//head/meta[lower-case(@property)="published-date"]/@content');
```
